### PR TITLE
fix: wait for a block before deploying AVS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,29 +13,28 @@ concurrency:
 
 
 jobs:
-  # TODO: fix package when running geth+lh
-  # run:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout Repository
-  #       uses: actions/checkout@v4
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-  #     - name: Setup Kurtosis
-  #       run: |
-  #         echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-  #         sudo apt update
-  #         if [ '1.3.0' = "latest" ]; then
-  #           sudo apt install kurtosis-cli
-  #         else
-  #           sudo apt install kurtosis-cli='1.3.0'
-  #         fi
-  #         kurtosis analytics disable
-  #         echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
-  #       shell: bash
+      - name: Setup Kurtosis
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          if [ '1.3.0' = "latest" ]; then
+            sudo apt install kurtosis-cli
+          else
+            sudo apt install kurtosis-cli='1.3.0'
+          fi
+          kurtosis analytics disable
+          echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH
+        shell: bash
 
-  #     - name: Run Package with default args
-  #       run: |
-  #         kurtosis run ./kurtosis_package
+      - name: Run Package with default args
+        run: |
+          kurtosis run ./kurtosis_package
 
   run_with_args:
     runs-on: ubuntu-latest

--- a/kurtosis_package/devnet_params.yaml
+++ b/kurtosis_package/devnet_params.yaml
@@ -8,7 +8,7 @@ avs_path: "contracts"
 
 ethereum_params:
   participants:
-    - el_type: reth
+    - el_type: besu
       cl_type: teku
   additional_services:
     - blockscout

--- a/kurtosis_package/main.star
+++ b/kurtosis_package/main.star
@@ -130,9 +130,10 @@ def run(plan, args={}):
     output_dir = "/app/{}/script/output/{}/".format(avs_path, chain_id)
 
     # Deploy the Incredible Squaring AVS contracts
+    # TODO: replace sleep with a call to plan.wait(...) or similar
     result = plan.run_sh(
         image=ics_deployer_img,
-        run="forge script ./script/IncredibleSquaringDeployer.s.sol --rpc-url ${HTTP_RPC_URL}  --private-key 0x${PRIVATE_KEY} --broadcast -vvv",
+        run="sleep 12 ; forge script ./script/IncredibleSquaringDeployer.s.sol --rpc-url ${HTTP_RPC_URL}  --private-key 0x${PRIVATE_KEY} --broadcast -vvv",
         env_vars={
             "HTTP_RPC_URL": http_rpc_url,
             "PRIVATE_KEY": private_key,


### PR DESCRIPTION
`geth` seems to execute mempool transactions not with its pending state, but with the latest block's state. This results in errors when trying to deploy the AVS. `geth` is used by default, so this made the `run` job fail.

This PR fixes this by adding a `sleep 12` before the AVS deployment.