### PR TITLE
docs: mention adding GOPATH to PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ install: generate_envscript ## 📦 Install the CLI
 	@echo
 	@echo "Installation successfull!"
 	@echo "Package was installed in $(INSTALLATION_DIR)"
-	@echo $(PATH) | grep -q $(INSTALLATION_DIR) || echo "\nWARNING: $(INSTALLATION_DIR) doesn't seem to be in your PATH. To add it, run:\nexport PATH=\"\$$PATH:$(INSTALLATION_DIR)\""
+	@echo $(PATH) | grep -q $(INSTALLATION_DIR) || echo "\nWARNING: $(INSTALLATION_DIR) doesn't seem to be in your PATH.\
+		\nIf the command can't be found, try adding to your ~/.bashrc the following line and restarting your shell:\
+		\nexport PATH=\"\$$PATH:$(INSTALLATION_DIR)\"\
+		\n"
 	@echo
 	@echo "Remember to run 'source env.sh' to set the environment variables"
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ Since the Devnet is implemented as a Kurtosis package, we require Kurtosis to be
 For how to install it, you can check [here](https://docs.kurtosis.com/install/).
 As part of that, you'll also need to install Docker.
 
-For local development, we require the `go` toolchain to be installed.
+For local development, we require [the `go` toolchain to be installed](https://go.dev/doc/install).
+
+> [!IMPORTANT]  
+> To be able to [install the CLI via `go`](#installation), you'll need to add `$HOME/go/bin` to your `PATH`.
+> You can do so by adding to your `~/.bashrc` (or the equivalent for your shell) the following line:
+>
+> ```bash
+> export PATH="$PATH:$HOME/go/bin"
+> ```
 
 ## Installation
 
@@ -27,9 +35,6 @@ make install   # installs the project
 # this command should be run once per shell
 source env.sh  # set env-vars
 ```
-
-> [!IMPORTANT]  
-> If this is your first time installing go binary packages on your computer, [you might need to add the binary location in your `PATH`](https://stackoverflow.com/a/70833125).
 
 ## How to Use
 


### PR DESCRIPTION
Depends on #78 

This PR addresses some friction when installing the command with `make install`.