### PR TITLE
chore: update branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ dev ]
   pull_request:
     branches: [ '**' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}
 
 env:
   KURTOSIS_VERSION: '1.4.1'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,10 +7,10 @@ To release a new version of the CLI, follow the steps below:
 > [!WARNING]
 > You need to have write permission to this repo to release a new version
 
-- [ ] Checkout `master` and pull the latest changes:
+- [ ] Checkout `dev` and pull the latest changes:
 
     ```sh
-    git checkout master && git pull origin master
+    git checkout dev && git pull origin dev
     ```
 
 - [ ] In your local clone, create a new tag:


### PR DESCRIPTION
This PR updates the main branch name to `dev` in CI and documentation. `dev` was chosen to be consistent with the naming of other org repos.