### PR TITLE
fix: add new `--broadcast` flag to `forge create`

### DIFF
--- a/kurtosis_package/deployers/eigenlayer.star
+++ b/kurtosis_package/deployers/eigenlayer.star
@@ -46,7 +46,7 @@ def deploy_mocktoken(plan, context, verify):
 
     verify_args = utils.get_verify_args(context) if verify else ""
 
-    cmd = "set -e ; forge create --rpc-url {} --private-key 0x{} {} src/ERC20Mock.sol:ERC20Mock 2> /dev/null \
+    cmd = "set -e ; forge create --broadcast --rpc-url {} --private-key 0x{} {} src/ERC20Mock.sol:ERC20Mock 2> /dev/null \
     | awk '/Deployed to: .*/{{ print $3 }}' | tr -d '\"\n'".format(
         http_rpc_url,
         private_key,


### PR DESCRIPTION
This PR adds the new `--broadcast` flag to `forge create`.