### PR TITLE
fix: use "JSONArgs" for entrypoint

### DIFF
--- a/kurtosis_package/dockerfiles/egnkey.Dockerfile
+++ b/kurtosis_package/dockerfiles/egnkey.Dockerfile
@@ -2,4 +2,4 @@ FROM golang:1.23
 
 RUN go install github.com/Layr-Labs/eigensdk-go/cmd/egnkey@565bb44
 
-ENTRYPOINT "egnkey"
+ENTRYPOINT ["egnkey"]


### PR DESCRIPTION
Building the egnkey image results in the following warning:

```
1 warning found (use docker --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals (line 5)
```

We fix this by using the arg list syntax, as specified in https://docs.docker.com/reference/build-checks/json-args-recommended/