### PR TITLE
ci: pin EigenDA version used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
         with:
           repository: Layr-Labs/eigenda
           path: eigenda/
+          ref: a294978e346fe9d7ede0f1a57012c36f64f1212a
       
       - name: Download SRS points
         run: |


### PR DESCRIPTION
Related to #164

Commit `344a052a5bcfb042fb313129060b42d3a263c223` in EigenDA breaks our example. For now, we're just pinning it to a previous commit.