### PR TITLE
fix: run forge install instead of build

### DIFF
--- a/kurtosis_package/dockerfiles/contract_deployer.Dockerfile
+++ b/kurtosis_package/dockerfiles/contract_deployer.Dockerfile
@@ -43,4 +43,4 @@ RUN git remote add origin ${CONTRACTS_REPO} && \
 WORKDIR /app/${CONTRACTS_PATH}
 
 # TODO: we can use a multi-stage build to store artifacts only
-RUN forge build
+RUN forge install


### PR DESCRIPTION
Depends on the fix from https://github.com/Layr-Labs/avs-devnet/pull/184