### PR TITLE
chore: pin hello-world-avs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ check_devnet:
 
 # hello-world-avs example
 
-HELLO_WORLD_REF:=master
+# Version from 2025-01-04
+HELLO_WORLD_REF:=4626e206fd119b26ebe98935b256daa7256e863b
 
 examples/hello-world-avs:
 	@echo "Cloning hello-world-avs repo..."


### PR DESCRIPTION
Pins the `hello-world-avs` to a working commit (we can go back to `master` once #85 is fixed).