### PR TITLE
chore: rename main binary to avs-devnet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,4 +164,4 @@ jobs:
         run: |
           cp examples/eigenda.yaml eigenda/devnet.yaml
           cd eigenda/
-          devnet start
+          avs-devnet start

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,9 +6,9 @@
 version: 2
 
 builds:
-  - id: devnet
-    main: ./cmd/devnet/main.go
-    binary: devnet
+  - id: avs-devnet
+    main: ./cmd/avs-devnet/main.go
+    binary: avs-devnet
     flags:
       - -v
     ldflags:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 KURTOSIS_DIR:=$(shell cd kurtosis_package/ && pwd -P)
 
 CURRENT_COMMIT:=$(shell git describe --always --abbrev=8 --dirty)
-INSTALLATION_DIR:=$(shell dirname $$(go list -f '{{.Target}}' cmd/devnet/main.go))
+INSTALLATION_DIR:=$(shell dirname $$(go list -f '{{.Target}}' cmd/avs-devnet/main.go))
 # These flags set some global constants in the build
 GO_LDFLAGS:='-X main.version=dev-$(CURRENT_COMMIT) -X github.com/Layr-Labs/avs-devnet/src/cmds/flags.DefaultKurtosisPackage=$(KURTOSIS_DIR)'
 
@@ -46,13 +46,13 @@ cli_deps:
 	go mod tidy
 
 devnet.yaml:
-	$(PACKAGE_ENV_VAR) go run cmd/devnet/main.go init
+	$(PACKAGE_ENV_VAR) go run cmd/avs-devnet/main.go init
 
 cli_start: devnet.yaml ## 🚀 Start the devnet (CLI)
-	$(PACKAGE_ENV_VAR) go run cmd/devnet/main.go start
+	$(PACKAGE_ENV_VAR) go run cmd/avs-devnet/main.go start
 
 cli_stop: devnet.yaml ## 🛑 Stop the devnet (CLI)
-	$(PACKAGE_ENV_VAR) go run cmd/devnet/main.go stop
+	$(PACKAGE_ENV_VAR) go run cmd/avs-devnet/main.go stop
 
 cli_fmt:
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This will create a new devnet config.
 By default it's stored as `devnet.yaml`, but another name can be passed as parameter.
 
 ```sh
-devnet init
+avs-devnet init
 ```
 
 The default configuration deploys EigenLayer with a single strategy and operator.
@@ -56,7 +56,7 @@ This will start a devnet according to the configuration inside `devnet.yaml`.
 Another file name can be specified as the first parameter.
 
 ```sh
-devnet start
+avs-devnet start
 ```
 
 Note that only one devnet per file name can be running at the same time.
@@ -68,7 +68,7 @@ This will stop the devnet according to the configuration inside `devnet.yaml`.
 Another file name can be specified as the first parameter.
 
 ```sh
-devnet stop
+avs-devnet stop
 ```
 
 ### Fetching the address of a contract
@@ -77,7 +77,7 @@ This will output the address of the deployed contract named `delegation`, from t
 In the default configuration, this corresponds to the address of EigenLayer's `DelegationManager`.
 
 ```sh
-$ devnet get-address eigenlayer_addresses:delegation
+$ avs-devnet get-address eigenlayer_addresses:delegation
 0x9f9F5Fd89ad648f2C000C954d8d9C87743243eC5
 ```
 
@@ -88,7 +88,7 @@ More examples:
 
 ```sh
 # print all addresses in eigenlayer_addresses artifact
-$ devnet get-address eigenlayer_addresses:
+$ avs-devnet get-address eigenlayer_addresses:
 {
   "addresses": {
     # ...
@@ -102,13 +102,13 @@ $ devnet get-address eigenlayer_addresses:
   # ...
 }
 # print the address under strategies -> MockETH
-$ devnet get-address eigenlayer_addresses:strategies.MockETH
+$ avs-devnet get-address eigenlayer_addresses:strategies.MockETH
 0x2b45cD38B213Bbd3A1A848bf2467927c976877Cb
 # because we also search nested entries, the last one can be shortened to
-$ devnet get-address eigenlayer_addresses:MockETH
+$ avs-devnet get-address eigenlayer_addresses:MockETH
 0x2b45cD38B213Bbd3A1A848bf2467927c976877Cb
 # by adding a . at the start, we disable the search function
-$ devnet get-address eigenlayer_addresses:.MockETH  # this fails
+$ avs-devnet get-address eigenlayer_addresses:.MockETH  # this fails
 Contract not found: eigenlayer_addresses:.MockETH
 ```
 
@@ -170,7 +170,7 @@ In that case, running it is as easy as:
 
 1. Install AvsDevnet
 2. Download the devnet configuration to use as `devnet.yaml`
-3. Run `devnet start` in the same folder
+3. Run `avs-devnet start` in the same folder
 
 Under `examples/` we have some devnet configurations that follow this approach.
 
@@ -223,12 +223,12 @@ artifacts:
 You can find the options for each command by appending `--help`:
 
 ```sh
-$ devnet --help
+$ avs-devnet --help
 NAME:
-   devnet - start an AVS devnet
+   avs-devnet - start an AVS devnet
 
 USAGE:
-   devnet [global options] command [command options]
+   avs-devnet [global options] command [command options]
 
 VERSION:
    development

--- a/cmd/avs-devnet/main.go
+++ b/cmd/avs-devnet/main.go
@@ -13,7 +13,7 @@ var version = "development"
 
 func main() {
 	app := cli.NewApp()
-	app.Name = "devnet"
+	app.Name = "avs-devnet"
 	app.Usage = "start an AVS devnet"
 	app.Version = version
 	app.Flags = append(app.Flags, &flags.KurtosisPackageFlag)

--- a/examples/eigenda.yaml
+++ b/examples/eigenda.yaml
@@ -15,7 +15,7 @@
 #    curl --range 0-2097151 -L https://srs-mainnet.s3.amazonaws.com/kzg/g1.point -o resources/g1.point
 #    curl --range 0-4194303 -L https://srs-mainnet.s3.amazonaws.com/kzg/g2.point -o resources/g2.point
 #    curl -L https://srs-mainnet.s3.amazonaws.com/kzg/g2.point.powerOf2 -o resources/g2.point.powerOf2
-# 4. Run `devnet start`
+# 4. Run `avs-devnet start`
 
 deployments:
   # NOTE: this script also deploys EigenLayer contracts

--- a/examples/hello_world_local.yaml
+++ b/examples/hello_world_local.yaml
@@ -9,7 +9,7 @@
 # 0. Ensure you have the latest version of the devnet (see the README for how to install)
 # 1. Clone the https://github.com/Layr-Labs/hello-world-avs repo
 # 2. Copy this file inside that repo (on the root)
-# 3. While inside that repo, run `devnet start hello_world_local.yaml`
+# 3. While inside that repo, run `avs-devnet start hello_world_local.yaml`
 
 deployments:
   - name: EigenLayer

--- a/examples/incredible_squaring_local.yaml
+++ b/examples/incredible_squaring_local.yaml
@@ -9,7 +9,7 @@
 # 0. Ensure you have the latest version of the devnet (see the README for how to install)
 # 1. Clone the https://github.com/Layr-Labs/incredible-squaring-avs repo
 # 2. Copy this file inside that repo (on the root)
-# 3. While inside that repo, run `devnet start incredible_squaring_local.yaml`
+# 3. While inside that repo, run `avs-devnet start incredible_squaring_local.yaml`
 
 deployments:
   - type: EigenLayer


### PR DESCRIPTION
Closes #143

This PR renames the binary to `avs-devnet`.