### PR TITLE
ci: remove testing from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,32 +10,7 @@ env:
   GO_VERSION: '1.22.4'
 
 jobs:
-  lint:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          working-directory: ./cli
-          version: latest
-
-  test:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Run go test
-        working-directory: ./cli
-        run: go test -v ./...
-
   release:
-    needs: [lint, test]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,8 @@ To release a new version of the CLI, follow the steps below:
 > [!WARNING]
 > You need to have write permission to this repo to release a new version
 
+- [ ] Check the last CI run on `main` succeeded.
+
 - [ ] Checkout `main` and pull the latest changes:
 
     ```sh


### PR DESCRIPTION
Since we already have a CI, we don't need this setup. We just have to wait for the CI to finish before making a release.