### PR TITLE
chore: parallelize test by starting subshell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ fmt: kurtosis_fmt cli_fmt ## 🧹 Format all code
 lint: kurtosis_lint cli_lint ## 🧹 Lint all code
 
 test: ## 🧪 Run tests
+	# NOTE: we do this to avoid race conditions in the engine initialization
+	kurtosis engine start
+
 	go test -v -timeout 30m ./...
 
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ fmt: kurtosis_fmt cli_fmt ## 🧹 Format all code
 
 lint: kurtosis_lint cli_lint ## 🧹 Lint all code
 
-test: ## 🧪 Run tests
+test: examples/hello-world-avs ## 🧪 Run tests
 	# NOTE: we do this to avoid race conditions in the engine initialization
 	kurtosis engine start
 

--- a/src/cmds/start_test.go
+++ b/src/cmds/start_test.go
@@ -3,7 +3,6 @@ package cmds_test
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -60,11 +59,9 @@ func TestStartIncredibleSquaring(t *testing.T) {
 }
 
 func TestStartLocalHelloWorld(t *testing.T) {
+	// Check that the Hello World AVS repo was downloaded
+	require.DirExists(t, filepath.Join(examplesDir, "hello-world-avs"), "Hello World AVS repo not found")
 	t.Parallel()
-	// Clone the hello-world-avs repo
-	err := exec.Command("sh", "-s", "cd "+rootDir+" && make examples/hello-world-avs").Run()
-	require.NoError(t, err, "Failed to make hello-world-avs repo")
-
 	configFile := filepath.Join(examplesDir, "hello_world_local.yaml")
 	devnetConfig, err := config.LoadFromPath(configFile)
 	require.NoError(t, err, "Failed to parse example config")

--- a/src/cmds/start_test.go
+++ b/src/cmds/start_test.go
@@ -77,11 +77,9 @@ func TestStartIncredibleSquaring(t *testing.T) {
 }
 
 func TestStartLocalHelloWorld(t *testing.T) {
-	// NOTE: we don't run t.Parallel() here because we need to change the working directory
-	goToDir(t, "../../")
-
+	t.Parallel()
 	// Clone the hello-world-avs repo
-	err := exec.Command("make", "examples/hello-world-avs").Run()
+	err := exec.Command("sh", "-s", "cd ../../ && make examples/hello-world-avs").Run()
 	require.NoError(t, err, "Failed to make hello-world-avs repo")
 
 	configFile := filepath.Join(examplesDir, "hello_world_local.yaml")

--- a/src/cmds/start_test.go
+++ b/src/cmds/start_test.go
@@ -46,23 +46,6 @@ func startDevnet(t *testing.T, devnetConfig config.DevnetConfig, workingDir stri
 	require.NoError(t, err, "Failed to start new devnet")
 }
 
-func goToDir(t *testing.T, destination string) {
-	dir, err := os.Getwd()
-	require.NoError(t, err, "Failed to get cwd")
-
-	err = os.Chdir(destination)
-	require.NoError(t, err, "Failed to go to repo root")
-
-	t.Cleanup(func() {
-		// Return to the original directory
-		err = os.Chdir(dir)
-		// Panic if failed, to avoid running other tests in the wrong directory
-		if err != nil {
-			panic(err)
-		}
-	})
-}
-
 func TestStartDefaultDevnet(t *testing.T) {
 	t.Parallel()
 	startDevnet(t, config.DefaultConfig(), examplesDir)

--- a/src/cmds/start_test.go
+++ b/src/cmds/start_test.go
@@ -62,7 +62,7 @@ func TestStartIncredibleSquaring(t *testing.T) {
 func TestStartLocalHelloWorld(t *testing.T) {
 	t.Parallel()
 	// Clone the hello-world-avs repo
-	err := exec.Command("sh", "-s", "cd ../../ && make examples/hello-world-avs").Run()
+	err := exec.Command("sh", "-s", "cd "+rootDir+" && make examples/hello-world-avs").Run()
 	require.NoError(t, err, "Failed to make hello-world-avs repo")
 
 	configFile := filepath.Join(examplesDir, "hello_world_local.yaml")


### PR DESCRIPTION
This PR makes `TestStartLocalHelloWorld` start a subshell to clone the repo, instead of changing the current directory. That allow us to run it in parallel with the rest.