### PR TITLE
feat!: unify cmd args

### DIFF
--- a/cmd/devnet/main.go
+++ b/cmd/devnet/main.go
@@ -17,28 +17,30 @@ func main() {
 	app.Usage = "start an AVS devnet"
 	app.Version = version
 
-	commonFlags := []cli.Flag{
-		&flags.ConfigFilePathFlag,
-	}
-
 	app.Commands = append(app.Commands, &cli.Command{
-		Name:   "init",
-		Usage:  "Initialize a devnet configuration file",
-		Flags:  commonFlags,
-		Action: cmds.InitCmd,
+		Name:      "init",
+		Usage:     "Initialize a devnet configuration file",
+		Args:      true,
+		ArgsUsage: "[<file-name>]",
+		Action:    cmds.InitCmd,
 	})
 
 	app.Commands = append(app.Commands, &cli.Command{
-		Name:   "start",
-		Usage:  "Start devnet from configuration file",
-		Flags:  append(commonFlags, &flags.KurtosisPackageFlag),
+		Name:      "start",
+		Usage:     "Start devnet from configuration file",
+		Args:      true,
+		ArgsUsage: "[<file-name>]",
+		Flags: []cli.Flag{
+			&flags.DevnetNameFlag,
+			&flags.KurtosisPackageFlag,
+		},
 		Action: cmds.StartCmd,
 	})
 
 	app.Commands = append(app.Commands, &cli.Command{
 		Name:   "stop",
 		Usage:  "Stop devnet from configuration file",
-		Flags:  commonFlags,
+		Flags:  []cli.Flag{&flags.DevnetNameFlag},
 		Action: cmds.StopCmd,
 	})
 
@@ -47,14 +49,14 @@ func main() {
 		Usage:     "Get a devnet contract or EOA address",
 		Args:      true,
 		ArgsUsage: "<contract-name>...",
-		Flags:     commonFlags,
+		Flags:     []cli.Flag{&flags.DevnetNameFlag},
 		Action:    cmds.GetAddress,
 	})
 
 	app.Commands = append(app.Commands, &cli.Command{
 		Name:   "get-ports",
 		Usage:  "Get the published ports on the devnet",
-		Flags:  commonFlags,
+		Flags:  []cli.Flag{&flags.DevnetNameFlag},
 		Action: cmds.GetPorts,
 	})
 

--- a/cmd/devnet/main.go
+++ b/cmd/devnet/main.go
@@ -16,37 +16,30 @@ func main() {
 	app.Name = "devnet"
 	app.Usage = "start an AVS devnet"
 	app.Version = version
-	app.Flags = append(app.Flags, &flags.KurtosisPackageFlag)
 
 	commonFlags := []cli.Flag{
 		&flags.ConfigFilePathFlag,
 	}
 
 	app.Commands = append(app.Commands, &cli.Command{
-		Name:      "init",
-		Usage:     "Initialize a devnet configuration file",
-		Args:      true,
-		ArgsUsage: "[<config-file>]",
-		Flags:     commonFlags,
-		Action:    cmds.InitCmd,
+		Name:   "init",
+		Usage:  "Initialize a devnet configuration file",
+		Flags:  commonFlags,
+		Action: cmds.InitCmd,
 	})
 
 	app.Commands = append(app.Commands, &cli.Command{
-		Name:      "start",
-		Usage:     "Start devnet from configuration file",
-		Args:      true,
-		ArgsUsage: "[<config-file>]",
-		Flags:     append(commonFlags, &flags.KurtosisPackageFlag),
-		Action:    cmds.StartCmd,
+		Name:   "start",
+		Usage:  "Start devnet from configuration file",
+		Flags:  append(commonFlags, &flags.KurtosisPackageFlag),
+		Action: cmds.StartCmd,
 	})
 
 	app.Commands = append(app.Commands, &cli.Command{
-		Name:      "stop",
-		Usage:     "Stop devnet from configuration file",
-		Args:      true,
-		ArgsUsage: "[<config-file>]",
-		Flags:     commonFlags,
-		Action:    cmds.StopCmd,
+		Name:   "stop",
+		Usage:  "Stop devnet from configuration file",
+		Flags:  commonFlags,
+		Action: cmds.StopCmd,
 	})
 
 	app.Commands = append(app.Commands, &cli.Command{
@@ -59,12 +52,10 @@ func main() {
 	})
 
 	app.Commands = append(app.Commands, &cli.Command{
-		Name:      "get-ports",
-		Usage:     "Get the published ports on the devnet",
-		Args:      true,
-		ArgsUsage: "[<config-file>]",
-		Flags:     commonFlags,
-		Action:    cmds.GetPorts,
+		Name:   "get-ports",
+		Usage:  "Get the published ports on the devnet",
+		Flags:  commonFlags,
+		Action: cmds.GetPorts,
 	})
 
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/devnet/main.go
+++ b/cmd/devnet/main.go
@@ -18,12 +18,16 @@ func main() {
 	app.Version = version
 	app.Flags = append(app.Flags, &flags.KurtosisPackageFlag)
 
+	commonFlags := []cli.Flag{
+		&flags.ConfigFilePathFlag,
+	}
+
 	app.Commands = append(app.Commands, &cli.Command{
 		Name:      "init",
 		Usage:     "Initialize a devnet configuration file",
 		Args:      true,
 		ArgsUsage: "[<config-file>]",
-		Flags:     []cli.Flag{},
+		Flags:     commonFlags,
 		Action:    cmds.InitCmd,
 	})
 
@@ -32,7 +36,7 @@ func main() {
 		Usage:     "Start devnet from configuration file",
 		Args:      true,
 		ArgsUsage: "[<config-file>]",
-		Flags:     []cli.Flag{},
+		Flags:     append(commonFlags, &flags.KurtosisPackageFlag),
 		Action:    cmds.StartCmd,
 	})
 
@@ -41,7 +45,7 @@ func main() {
 		Usage:     "Stop devnet from configuration file",
 		Args:      true,
 		ArgsUsage: "[<config-file>]",
-		Flags:     []cli.Flag{},
+		Flags:     commonFlags,
 		Action:    cmds.StopCmd,
 	})
 
@@ -50,7 +54,7 @@ func main() {
 		Usage:     "Get a devnet contract or EOA address",
 		Args:      true,
 		ArgsUsage: "<contract-name>...",
-		Flags:     []cli.Flag{&flags.ConfigFilePathFlag},
+		Flags:     commonFlags,
 		Action:    cmds.GetAddress,
 	})
 
@@ -59,7 +63,7 @@ func main() {
 		Usage:     "Get the published ports on the devnet",
 		Args:      true,
 		ArgsUsage: "[<config-file>]",
-		Flags:     []cli.Flag{},
+		Flags:     commonFlags,
 		Action:    cmds.GetPorts,
 	})
 

--- a/src/cmds/flags/flags.go
+++ b/src/cmds/flags/flags.go
@@ -11,9 +11,11 @@ var DefaultKurtosisPackage string = ""
 //nolint:gochecknoglobals // these are constants
 var (
 	ConfigFilePathFlag = cli.StringFlag{
-		Name:  "config-file",
-		Usage: "Path to the devnet configuration file",
-		Value: "devnet.yaml",
+		Name:      "file",
+		TakesFile: true,
+		Aliases:   []string{"f"},
+		Usage:     "Path to the devnet configuration file",
+		Value:     "devnet.yaml",
 	}
 
 	// NOTE: this flag is for internal use.

--- a/src/cmds/flags/flags.go
+++ b/src/cmds/flags/flags.go
@@ -10,12 +10,13 @@ var DefaultKurtosisPackage string = ""
 
 //nolint:gochecknoglobals // these are constants
 var (
-	ConfigFilePathFlag = cli.StringFlag{
-		Name:      "file",
-		TakesFile: true,
-		Aliases:   []string{"f"},
-		Usage:     "Path to the devnet configuration file",
-		Value:     "devnet.yaml",
+	DevnetNameFlag = cli.StringFlag{
+		Name:        "name",
+		TakesFile:   true,
+		Aliases:     []string{"n"},
+		Usage:       "Assign a name to the devnet",
+		Value:       "devnet",
+		DefaultText: "devnet",
 	}
 
 	// NOTE: this flag is for internal use.

--- a/src/cmds/get_address.go
+++ b/src/cmds/get_address.go
@@ -14,11 +14,7 @@ import (
 
 func GetAddress(ctx *cli.Context) error {
 	args := ctx.Args()
-	configFileName := ctx.String(flags.ConfigFilePathFlag.Name)
-	devnetName, err := EnclaveNameFromFileName(configFileName)
-	if err != nil {
-		return cli.Exit(err, 1)
-	}
+	devnetName := flags.DevnetNameFlag.Get(ctx)
 
 	kurtosisCtx, err := kurtosis.InitKurtosisContext()
 	if err != nil {

--- a/src/cmds/get_ports.go
+++ b/src/cmds/get_ports.go
@@ -3,16 +3,14 @@ package cmds
 import (
 	"fmt"
 
+	"github.com/Layr-Labs/avs-devnet/src/cmds/flags"
 	"github.com/Layr-Labs/avs-devnet/src/kurtosis"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
 )
 
 func GetPorts(ctx *cli.Context) error {
-	devnetName, _, err := parseArgs(ctx)
-	if err != nil {
-		return cli.Exit(err, 1)
-	}
+	devnetName := flags.DevnetNameFlag.Get(ctx)
 
 	kurtosisCtx, err := kurtosis.InitKurtosisContext()
 	if err != nil {

--- a/src/cmds/init.go
+++ b/src/cmds/init.go
@@ -11,7 +11,7 @@ import (
 
 // Creates a new devnet configuration with the given context.
 func InitCmd(ctx *cli.Context) error {
-	_, configFileName, err := parseArgs(ctx)
+	configFileName, err := parseConfigFileName(ctx)
 	if err != nil {
 		return cli.Exit(err, 1)
 	}

--- a/src/cmds/start.go
+++ b/src/cmds/start.go
@@ -24,7 +24,8 @@ import (
 // Starts the devnet with the given context.
 func StartCmd(ctx *cli.Context) error {
 	pkgName := flags.KurtosisPackageFlag.Get(ctx)
-	devnetName, configPath, err := parseArgs(ctx)
+	devnetName := flags.DevnetNameFlag.Get(ctx)
+	configPath, err := parseConfigFileName(ctx)
 	if err != nil {
 		return cli.Exit(err, 1)
 	}

--- a/src/cmds/stop.go
+++ b/src/cmds/stop.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Layr-Labs/avs-devnet/src/cmds/flags"
 	"github.com/Layr-Labs/avs-devnet/src/kurtosis"
 	"github.com/urfave/cli/v2"
 )
@@ -13,12 +14,9 @@ var ErrEnclaveNotExists = errors.New("enclave doesn't exist")
 
 // Stops the devnet with the given context.
 func StopCmd(ctx *cli.Context) error {
-	devnetName, _, err := parseArgs(ctx)
-	if err != nil {
-		return cli.Exit(err, 1)
-	}
+	devnetName := flags.DevnetNameFlag.Get(ctx)
 	fmt.Println("Stopping devnet...")
-	err = Stop(ctx.Context, devnetName)
+	err := Stop(ctx.Context, devnetName)
 	if errors.Is(err, ErrEnclaveNotExists) {
 		return cli.Exit("Failed to find '"+devnetName+"'. Maybe it's not running?", 1)
 	} else if err != nil {

--- a/src/cmds/utils.go
+++ b/src/cmds/utils.go
@@ -3,47 +3,31 @@ package cmds
 import (
 	"errors"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/urfave/cli/v2"
 )
 
-// Parses the main arguments from the given context.
-// Returns the devnet name and the configuration file name.
-func parseArgs(ctx *cli.Context) (string, string, error) {
+// Parses the configuration file path from the positional args.
+// Fails if more than one positional arg is provided.
+func parseConfigFileName(ctx *cli.Context) (string, error) {
 	args := ctx.Args()
 	if args.Len() > 1 {
-		return "", "", errors.New("expected exactly 1 argument: <config-file>")
+		return "", errors.New("expected none or 1 argument: [<file-name>]")
 	}
 	fileName := args.First()
-	var devnetName string
-
+	// TODO: check file exists and support yml extension
 	if fileName == "" {
-		fileName = "devnet.yaml"
-		devnetName = "devnet"
-	} else {
-		name, err := EnclaveNameFromFileName(fileName)
-		if err != nil {
-			return "", "", err
-		}
-		devnetName = name
+		return "devnet.yaml", nil
 	}
-	return devnetName, fileName, nil
+	return fileName, nil
 }
 
 // Checks if a file exists at the given path.
 func fileExists(filePath string) bool {
 	_, err := os.Stat(filePath)
 	return !errors.Is(err, os.ErrNotExist)
-}
-
-// Extracts the devnet name from the given configuration file name.
-func EnclaveNameFromFileName(fileName string) (string, error) {
-	name := filepath.Base(fileName)
-	name = strings.Split(name, ".")[0]
-	return ToValidEnclaveName(name)
 }
 
 func ToValidEnclaveName(name string) (string, error) {


### PR DESCRIPTION
Closes #90

This PR drops the config file flag and positional argument in all but the `init` and `start` subcommands. It also adds a `--name`/`-n` flag for specifying a name for the devnet (which defaults to `devnet`).