### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ avs-devnet start
 Note that only one devnet per file name can be running at the same time.
 Trying to start another one (or the same one more than once) will fail.
 
+> [!TIP]
+> If you're having any problems running the devnet, check the ["Troubleshooting"](#troubleshooting) section for known issues.
+> If that doesn't help, feel free to open an issue [here](https://github.com/Layr-Labs/avs-devnet/issues/new?template=bug_report.md).
+
 ### Stopping the devnet
 
 This will stop the devnet according to the configuration inside `devnet.yaml`.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note that only one devnet per file name can be running at the same time.
 Trying to start another one (or the same one more than once) will fail.
 
 > [!TIP]
-> If you're having any problems running the devnet, check the ["Troubleshooting"](#troubleshooting) section for known issues.
+> If you encounter any issues while running the devnet, check the ["Troubleshooting"](#troubleshooting) section for known problems.
 > If that doesn't help, feel free to open an issue [here](https://github.com/Layr-Labs/avs-devnet/issues/new?template=bug_report.md).
 
 ### Stopping the devnet

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This will output the address of the deployed contract named `delegation`, from t
 In the default configuration, this corresponds to the address of EigenLayer's `DelegationManager`.
 
 ```sh
-$ avs-devnet get-address eigenlayer_addresses:delegation
+$ avs-devnet get-address eigenlayer_addresses:delegationManager
 0x9f9F5Fd89ad648f2C000C954d8d9C87743243eC5
 ```
 


### PR DESCRIPTION
This PR adds a TIP linking to "Troubleshooting" right after the `avs-devnet start` command documentation. Also, it fixes one of the commands that didn't work due to the "delegation" -> "delegationManager" change from core contracts.